### PR TITLE
Drakvuf write file option

### DIFF
--- a/src/exitcodes.h
+++ b/src/exitcodes.h
@@ -113,5 +113,6 @@ enum drakvuf_exit_code_t
     INJECTION_UNSUCCESSFUL = 4, /* Injection has been done correctly, but
                                  * the sample could not be started
                                  * (corrupted, arch mismatch and so on) */
+    WRITE_FILE_ERROR = 5,
     KERNEL_PANIC = 10,
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@
 #include <memory>
 
 #include <map>
-#include <string>
+#include <filesystem>
 
 #include "drakvuf.h"
 #include "exitcodes.h"
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
     uint64_t limited_traps_ttl = UNLIMITED_TTL;
     char const* inject_file = nullptr;
     char const* inject_cwd = nullptr;
-    std::map<std::string, std::string> write_files;
+    std::map<std::filesystem::path, std::filesystem::path> write_files;
     injection_method_t injection_method = INJECT_METHOD_CREATEPROC;
     int injection_timeout = 0;
     bool injection_global_search = false;
@@ -537,7 +537,13 @@ int main(int argc, char** argv)
             case opt_write_file:
                 if (optind >= argc || *argv[optind] == '-')
                 {
-                    fprintf(stderr, "Missing <dst> parameter for write-file injection!\n");
+                    fprintf(stderr, "--write-file <dst> parameter is missing!\n");
+                    return drakvuf_exit_code_t::FAIL;
+                }
+
+                if (!std::filesystem::exists(optarg))
+                {
+                    fprintf(stderr, "--write-file <src> file (%s) not found!\n", optarg);
                     return drakvuf_exit_code_t::FAIL;
                 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -819,7 +819,7 @@ int main(int argc, char** argv)
     {
         PRINT_DEBUG("Writing file ('%s' -> '%s') into running VM\n", src.c_str(), dst.c_str());
 
-        injector_status_t ret = drakvuf->inject_cmd(injection_pid, injection_thread, dst.c_str(), nullptr, INJECT_METHOD_WRITE_FILE, output, src.c_str(), nullptr, injection_timeout, injection_global_search, 0, nullptr, &injected_pid);
+        injector_status_t ret = drakvuf->inject_cmd(injection_pid, injection_thread, dst.c_str(), nullptr, INJECT_METHOD_WRITE_FILE, output, src.c_str(), nullptr, 0, true, 0, nullptr, &injected_pid);
         if (ret != INJECTOR_SUCCEEDED)
         {
             fprintf(stderr, "Failed to copy file (%s) into VM!\n", src.c_str());


### PR DESCRIPTION
Add --write-file <src> <dst> option to drakvuf that uses INJECT_METHOD_WRITE_FILE inject method of libinjector to copy file into the running VM. Can be used multiple times.